### PR TITLE
Make encrypt input and decrypt STOUT symmetrical

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -18,5 +18,5 @@ const encryptionAlgo = argv.algo || argv.a
 const cryptography = require('./cryptography')
 
 
-if (argv.decrypt || argv.d) log(cryptography.decrypt({secret, outputFile, encryptionAlgo}),'info')
+if (argv.decrypt || argv.d) console.log(cryptography.decrypt({secret, outputFile, encryptionAlgo}))
 	else cryptography.encrypt({ secret, inputFile, outputFile, encryptionAlgo });


### PR DESCRIPTION
The problem here is that the previous output appended log information to STDOUT

```bash
Secure-env :  INFO SENTRY_DSN=something
BING_SUBSCRIPTION_KEY=something_else
```

This has now become an invalid `.env` file.

This made it difficult to use this in combination with other tools, e.g. to regenerate a local `.env` file as part of a build tool. 

My recommendation here is to remove this meta-information when decrypting such that we get

```bash
SENTRY_DSN=something
BING_SUBSCRIPTION_KEY=something_else
```